### PR TITLE
chore(deps): specify a commit hash for the jsdoc-baseline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "jsdoc": "^3.6.2",
-    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git#222e13a",
+    "jsdoc-baseline": "^0.1.1",
     "linkinator": "^1.4.0",
     "mocha": "^6.0.0",
     "prettier": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "jsdoc": "^3.6.2",
-    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
+    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git#222e13a",
     "linkinator": "^1.4.0",
     "mocha": "^6.0.0",
     "prettier": "^1.17.0",


### PR DESCRIPTION
I plan to make breaking changes to the hegemonic/jsdoc-baseline repo. To ensure that your repo is not affected by these breaking changes, this pull request pins the `jsdoc-baseline` package to a specific commit hash.

If you prefer, you can use the [NPM release of this package](https://www.npmjs.com/package/jsdoc-baseline) instead by setting the `jsdoc-baseline` property to `^0.1.1`.